### PR TITLE
Set log level in syslog messages

### DIFF
--- a/lib/syslog.ex
+++ b/lib/syslog.ex
@@ -39,7 +39,6 @@ defmodule Logger.Backends.Syslog do
       |> Logger.Formatter.compile
 
     level    = Keyword.get(syslog, :level)
-    level_num = level |> Logger.Syslog.Utils.level
     metadata = Keyword.get(syslog, :metadata, [])
     host     = Keyword.get(syslog, :host, '127.0.0.1')
     port     = Keyword.get(syslog, :port, 514)
@@ -47,14 +46,14 @@ defmodule Logger.Backends.Syslog do
     appid    = Keyword.get(syslog, :appid, :elixir)
     [hostname | _] = String.split("#{:net_adm.localhost()}", ".")
     %{format: format, metadata: metadata, level: level, socket: socket,
-      host: host, port: port, facility: facility, appid: appid,
-      level_num: level_num, hostname: hostname}
+      host: host, port: port, facility: facility, appid: appid, hostname: hostname}
   end
 
   defp log_event(level, msg, ts, md, state) do
     %{format: format, metadata: metadata, facility: facility, appid: appid,
-    hostname: _hostname, host: host, port: port, socket: socket, level_num: level_num} = state
+    hostname: _hostname, host: host, port: port, socket: socket} = state
 
+    level_num = Logger.Syslog.Utils.level(level)
     pre = :io_lib.format('<~B>~s ~s~p: ', [facility ||| level_num,
       Logger.Syslog.Utils.iso8601_timestamp(ts), appid, self])
 


### PR DESCRIPTION
So far every syslog message had a fixed log level. Now the log level set in elixir will be passed on to syslog.
